### PR TITLE
Fixed a bug where valid faction code is deemed invalid

### DIFF
--- a/twisted_fate/deck_coder/deckCoder.py
+++ b/twisted_fate/deck_coder/deckCoder.py
@@ -138,8 +138,8 @@ class DeckCode:
                     print(f"code is not digit: {char}")
                     return False
 
-            faction = faction_code_to_id.get(code[2:4], False)
-            if not faction:
+            faction = faction_code_to_id.get(code[2:4], -1)
+            if faction < 0:
                 print(f"faction code not in faction code list: {code[2:4]}")
                 return False
 


### PR DESCRIPTION
Steps to reproduce the error.
```
deck = twisted_fate.Deck.decode('CEBASAIAAEEQUDA2DUVS2MYCAIAAGCICAEAQAJYCAIAAKBYBAEAQAMQ')
print(deck.to_deck_code())
```
